### PR TITLE
Added JumpIfZero to generic IR.

### DIFF
--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -1440,6 +1440,14 @@ impl<'a, E: ExternalFunctions> Interpreter<'a, E> {
                         should_inc_pc = false;
                     }
                 }
+                Directive::JumpIfZero { target, condition } => {
+                    let target = self.labels[&target].pc;
+                    let cond = self.get_vrom_relative_u32(condition..condition + 1);
+                    if cond == 0 {
+                        self.pc = target;
+                        should_inc_pc = false;
+                    }
+                }
                 Directive::Jump { target } => {
                     self.pc = self.labels[&target].pc;
                     should_inc_pc = false;


### PR DESCRIPTION
IR generation is controlled by trait `Settings`, and one of the options in this trait is if the IR support the `JumpIfZero` or `JumpIfNonZero` instructions.  The code generator work with either or both, but the generic IR defined inside Womir and used to run all the tests only had `JumpIfNonZero` instructions.

This PR adds `JumpIfZero` instruction , which allow for smaller code in some cases.