### PR TITLE
Removing dumb jumps.

### DIFF
--- a/TODO-optimizations.txt
+++ b/TODO-optimizations.txt
@@ -40,14 +40,6 @@ This files describes all the optimizations ideas we left out for now.
   destination instead of going through multiple frame barriers, because
   each frame barrier potentially adds multiple copies.
 
-- after flattening the DAG, there might remain Jump instructions that
-  targets a label that follows immediately. These Jumps can be eliminated.
-  This is important even when compiling an optimized WASM, because
-  the Br nodes are added explicitly during the DAG processing, even
-  on blocks that falls through (which is needed to properly handle
-  the data flow from breaks to labels). And these Br nodes may generate
-  these superfluous Jumps.
-
 - [tail call]: a call immediately followed by a return can be optimized
   to a tail call. We can even do this for calls where its outputs
   are not related to the return values, because we can set the

--- a/src/generic_ir.rs
+++ b/src/generic_ir.rs
@@ -138,6 +138,14 @@ impl<'a> Settings<'a> for GenericIrSetting {
         directives
     }
 
+    fn is_label(directive: &Self::Directive) -> Option<&str> {
+        if let Directive::Label { id, .. } = directive {
+            Some(id)
+        } else {
+            None
+        }
+    }
+
     fn to_plain_local_jump(directive: Directive) -> Result<String, Directive> {
         if let Directive::Jump { target } = directive {
             Ok(target)

--- a/src/loader/dumb_jump_removal.rs
+++ b/src/loader/dumb_jump_removal.rs
@@ -1,0 +1,46 @@
+//! This module implements a simple pass to remove dumb jumps, i.e. jumps that
+//! plainly jump to the next instruction unconditionally.
+//!
+//! This must be done after flattening, because breaks are important to
+//! generate the appropriate argument copy instructions.
+
+use crate::loader::flattening::{WriteOnceASM, settings::Settings};
+
+pub fn remove_dumb_jumps<'a, S: Settings<'a>>(
+    s: &S,
+    asm: &mut WriteOnceASM<S::Directive>,
+) -> usize {
+    let mut removed = 0;
+
+    let old_directives = std::mem::take(&mut asm.directives);
+    asm.directives.reserve(old_directives.len());
+
+    let mut old_directives = old_directives.into_iter();
+    let Some(mut prev_directive) = old_directives.next() else {
+        // Is it even possible for a valid function to be empty?
+        return 0;
+    };
+
+    for curr_directive in old_directives {
+        match S::to_plain_local_jump(prev_directive) {
+            Ok(jump) => {
+                if S::is_label(&curr_directive) == Some(&jump) {
+                    // This is a dumb jump, don't keep it.
+                    removed += 1;
+                } else {
+                    // Current directive is not a label matching the preceding jump,
+                    // so we keep the jump.
+                    asm.directives.push(s.emit_jump(jump));
+                }
+            }
+            Err(prev_directive) => {
+                // This is not a jump, keep it.
+                asm.directives.push(prev_directive);
+            }
+        };
+        prev_directive = curr_directive;
+    }
+    asm.directives.push(prev_directive);
+
+    removed
+}

--- a/src/loader/flattening/settings.rs
+++ b/src/loader/flattening/settings.rs
@@ -108,6 +108,9 @@ pub trait Settings<'a> {
     /// Test if a directive is a plain jump to a local frame label.
     fn to_plain_local_jump(directive: Self::Directive) -> Result<String, Self::Directive>;
 
+    /// Test if a directive is a label.
+    fn is_label(directive: &Self::Directive) -> Option<&str>;
+
     /// Emits a directive to mark a code position, and possibly a frame size.
     fn emit_label(
         &self,


### PR DESCRIPTION
For ease of processing, explicit breaks are inserted at the end of blocks, instead of letting a block fall through. These breaks are propagated until they eventually become unconditional jumps to the immediately following instruction.

This optimization pass removes such jumps that are effectively NOPs.

Unfortunately this breaks interface because a new function was needed on settings, to test if a directive is a label.