### PR TITLE
use call suffix directives in Call as well

### DIFF
--- a/src/loader/flattening/mod.rs
+++ b/src/loader/flattening/mod.rs
@@ -749,6 +749,7 @@ fn translate_single_node<'a, S: Settings<'a>>(
                             call.ret_info.ret_fp,
                         )
                         .into(),
+                    call.suffix_directives.into(),
                 ])
             }
         }


### PR DESCRIPTION
`prepare_function_call` returns instructions to be done before a call, the call instructions, and instructions to be done after the call. The latter was introduced for `copy_from_frame`. It was used by the `CallIndirect` codegen, but not by `Call`.