### PR TITLE
Removing redundant emit_table_get().

### DIFF
--- a/src/generic_ir.rs
+++ b/src/generic_ir.rs
@@ -293,20 +293,6 @@ impl<'a> Settings<'a> for GenericIrSetting {
         }
     }
 
-    fn emit_table_get(
-        &self,
-        _c: &mut Ctx,
-        table_idx: u32,
-        entry_idx_ptr: Range<u32>,
-        dest_ptr: Range<u32>,
-    ) -> Directive<'a> {
-        Directive::WASMOp {
-            op: Op::TableGet { table: table_idx },
-            inputs: vec![entry_idx_ptr],
-            output: Some(dest_ptr),
-        }
-    }
-
     fn emit_wasm_op(
         &self,
         _c: &mut Ctx,

--- a/src/loader/flattening/mod.rs
+++ b/src/loader/flattening/mod.rs
@@ -780,8 +780,13 @@ fn translate_single_node<'a, S: Settings<'a>>(
             )?;
 
             vec![
-                s.emit_table_get(ctx, table_index, entry_idx, func_ref_reg)
-                    .into(),
+                s.emit_wasm_op(
+                    ctx,
+                    Op::TableGet { table: table_index },
+                    vec![WasmOpInput::Register(entry_idx)],
+                    Some(func_ref_reg),
+                )
+                .into(),
                 s.emit_conditional_jump_cmp_immediate(
                     ctx,
                     ComparisonFunction::Equal,

--- a/src/loader/settings.rs
+++ b/src/loader/settings.rs
@@ -328,15 +328,6 @@ pub trait Settings<'a> {
         saved_caller_fp_ptr: Range<u32>,
     ) -> impl Into<Tree<Self::Directive>>;
 
-    /// Emits the instructions to retrieve a function pointer from a table entry.
-    fn emit_table_get(
-        &self,
-        c: &mut Context<'a, '_, Self>,
-        table_idx: u32,
-        entry_idx_ptr: Range<u32>,
-        dest_ptr: Range<u32>,
-    ) -> impl Into<Tree<Self::Directive>>;
-
     /// Emits the equivalent set of instructions to a WASM operation.
     fn emit_wasm_op(
         &self,


### PR DESCRIPTION
This trait function is contained in `emit_was_op()`