### PR TITLE
Add Context::module() accessor

### DIFF
--- a/src/loader/rwm/flattening/mod.rs
+++ b/src/loader/rwm/flattening/mod.rs
@@ -778,6 +778,14 @@ impl<'a, 'b> Context<'a, 'b> {
     pub fn new_label(&self, label_type: LabelType) -> String {
         format_label(self.common.label_gen.next(), label_type)
     }
+
+    /// Returns a reference to the module being processed.
+    ///
+    /// The returned reference has lifetime `'b` (independent of the `&self` borrow),
+    /// so callers can use it alongside `&mut self` without borrow conflicts.
+    pub fn module(&self) -> &'b Module<'a> {
+        self.common.prog
+    }
 }
 
 struct FunctionCall<D> {


### PR DESCRIPTION
Expose the Module reference from the flattening Context so that Settings implementations can access module data (e.g. function types) without needing to store a separate module reference.

Returns &'b Module<'a> so the borrow doesn't conflict with &mut self.